### PR TITLE
Allow resetting location by checking if param is explicitly passed

### DIFF
--- a/Functions/Publish-SfBContactInformation.ps1
+++ b/Functions/Publish-SfBContactInformation.ps1
@@ -115,7 +115,9 @@ function Publish-SfBContactInformation {
             $ContactInfo.Add([Microsoft.Lync.Model.PublishableContactInformationType]::PersonalNote, $PersonalNote)
         }
 
-        if ($Location) {
+	
+	# allow default/empty value
+        if ($PSBoundParameters.ContainsKey('Location')) {
             $ContactInfo.Add([Microsoft.Lync.Model.PublishableContactInformationType]::LocationName, $Location)
         }
 


### PR DESCRIPTION
Fixes #10 

`$PSBoundParameters.ContainsKey('Location')` tells you whether an argument was explicitly passed to `-Location`, therefore allowing you to pass the default value (an empty string) and still return true.